### PR TITLE
Add all-time chart feature

### DIFF
--- a/aligulac/aligulac/urls.py
+++ b/aligulac/aligulac/urls.py
@@ -27,7 +27,9 @@ urlpatterns = patterns('',
     url(r'^results/events/(?P<event_id>\d+)(-[^ /]*)?/$', 'ratings.views.events'),
     url(r'^results/search/$', 'ratings.views.results_search'),
 
-    url(r'^records/$', 'ratings.views.records'),
+    url(r'^records/race/$', 'ratings.views.records_race'),
+    url(r'^records/history/$', 'ratings.views.records_history'),
+    url(r'^records/hof/$', 'ratings.views.records_hof'),
 
     url(r'^predict/$', 'ratings.predict.predict'),
     url(r'^predict/match/$', 'ratings.predict.pred_match'),

--- a/aligulac/aligulac/views.py
+++ b/aligulac/aligulac/views.py
@@ -92,7 +92,7 @@ def base_ctx(section=None, subpage=None, request=None, context=None):
     curp = Period.objects.filter(computed=True).order_by('-start')[0]
     menu = [('Ranking', '/periods/%i' % curp.id),\
             ('Teams', '/teams/'),\
-            ('Records', '/records/'),\
+            ('Records', '/records/history'),\
             ('Results', '/results/'),\
             ('Reports', '/reports/'),\
             ('Predict', '/predict/'),\
@@ -107,11 +107,12 @@ def base_ctx(section=None, subpage=None, request=None, context=None):
         base['user'] = request.user.username
 
     if section == 'Records':
-        base['submenu'] = [('HoF', '/records/?race=hof'),\
-                           ('All', '/records/?race=all'),\
-                           ('Protoss', '/records/?race=P'),\
-                           ('Terran', '/records/?race=T'),\
-                           ('Zerg', '/records/?race=Z')]
+        base['submenu'] = [('History', '/records/history/'),
+                           ('HoF', '/records/hof/'),\
+                           ('All', '/records/race/?race=all'),\
+                           ('Protoss', '/records/race/?race=P'),\
+                           ('Terran', '/records/race/?race=T'),\
+                           ('Zerg', '/records/race/?race=Z')]
     elif section == 'Results':
         base['submenu'] = [('By Date', '/results/'),\
                            ('By Event', '/results/events/'),\

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,269 @@
+{% extends "index.html" %}
+
+{% comment %}
+This is the Hall of Fame template. It's called from ratings.views.records.
+{% endcomment %}
+
+{% load ratings_extras %}
+
+{% block title %}History{% endblock %}
+
+{% block content %}
+<h2>History</h2>
+
+
+<form method="get" action="/records/history/">
+    <p>Show the:
+    <select name="numPlayers">
+        <option value=5 {% if numPlayers == 5 %}selected{% endif %}>5</option>
+        <option value=10 {% if numPlayers == 10 %}selected{% endif %}>10</option>
+        <option value=20 {% if numPlayers == 20 %}selected{% endif %}>20</option>
+        <option value=50 {% if numPlayers == 50 %}selected{% endif %}>50</option>
+        <option value=100 {% if numPlayers == 100 %}selected{% endif %}>100</option>
+    </select>
+    best players by races:
+    <select name="race">
+        <option value="ptzrs" {% if race == "ptzrs" %}selected{% endif %}>All</option>
+        <option value="p" {% if race == "p" %}selected{% endif %}>Protoss</option>
+        <option value="t" {% if race == "t" %}selected{% endif %}>Terran</option>
+        <option value="z" {% if race == "z" %}selected{% endif %}>Zerg</option>
+        <option value="tzrs" {% if race == "tzrs" %}selected{% endif %}>No Protoss</option>
+        <option value="pzrs" {% if race == "pzrs" %}selected{% endif %}>No Terran</option>
+        <option value="ptrs" {% if race == "ptrs" %}selected{% endif %}>No Zerg</option>
+    </select>
+    and nationalities:
+    <select name="nats">
+        <option value="all" {% if nats == "all" %}selected{% endif %}>All</option>
+        <option value="foreigners" {% if nats == "foreigners" %}selected{% endif %}>Non-Koreans</option>
+        {% for c in countries %}
+        <option value="{{ c.cc }}" {% if nats == c.cc %}selected{% endif %}>{{ c.name }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Filter" />
+    </p>
+</form>
+
+<script type="text/javascript">
+    $(document).ready(function() { 
+        var chart1 = new Highcharts.Chart({
+            chart: {
+                renderTo: 'chart-alltime',
+                type: 'spline',
+                zoomType: 'xy'
+            },
+            credits: {
+                enabled: false
+            },
+            title: {
+                text: ''
+            },
+            subtitle: {
+                text: 'Click and drag to zoom'
+            },
+            xAxis: {
+                type: 'datetime',
+                plotLines: [
+                {% for p in patches %}
+                {
+                    value: {{ p.0|milliseconds }},
+                    color: '#cccccc',
+                    width: 2,
+                    label: {
+                        text: '{{ p.1 }}',
+                        verticalAlign: 'bottom',
+                        textAlign: 'right',
+                        y: -2,
+                        style: {
+                            fontSize: '0.8em',
+                        }
+                    }
+                },
+                {% endfor %}]
+            },
+            yAxis: {
+                title: {
+                    text: 'Ranking' 
+                },
+                min: 800,
+                max: 2100
+            },
+            tooltip: {
+                enabled: true,
+                formatter: function () {
+                    return this.series.name;
+                }
+            },
+            plotOptions: {
+                series: {
+                    events: {
+                        mouseOver: function() {                      
+                            this.hasCustomFlag = this.color;
+                        },
+                        mouseOut: function() {
+                            this.graph.attr('stroke', this.hasCustomFlag);
+                        }
+                    },
+                    states: {
+                        hover: {
+                            lineWidth : 6
+                        }
+                    },
+                    marker: {
+                        enabled: false,
+                        states: {
+                            hover: {
+                              enabled: false,
+                            }
+                        }
+                    },
+                },
+            },
+             series: [
+
+             {% for player, rating in records %}
+             { 
+                name: '{{ player.tag }}',
+                {% if player.race == "T" %}
+                    color: '#0000dd',
+                {% elif player.race == "Z" %}
+                    color: '#dd0000',
+                {% elif player.race == "P" %}
+                    color: '#00dd00',
+                {% else %}
+                    color: '#000000',
+                {% endif %}
+                lineWidth: 1,
+                
+
+
+                data: [{% for r in rating %} {
+                          name: '{{ r.period.end }}: {{r.bf_rating|ratscale }}',
+                          x: {{ r.period.end|milliseconds }},
+                          y: {{ r.bf_rating|ratscale }}
+                      },{% endfor %}]
+
+                
+            },
+            {% endfor %}] 
+           
+        });
+    });
+</script>
+<div style="width: 67em; height: 40em;" id="chart-alltime"></div>
+
+{% endblock %}
+
+
+
+
+
+           {% comment %}
+
+
+
+
+
+
+
+
+data: [{% for r in rating %}
+                          [ {{ r.period.end|milliseconds }}, {{ r.bf_rating|addf:r.bf_rating_vp|ratscale }} ],
+                      ,{% endfor %}]
+
+
+
+data: [{% for r in rating %}{
+                          [ {{ r.period.end|milliseconds }}, {{ r.bf_rating|addf:r.bf_rating_vp|ratscale }} ],
+                      },{% endfor %}]
+
+
+      
+
+chart: {
+                renderTo: 'chart',
+                type: 'spline',
+                zoomType: 'xy'
+            },
+            credits: {
+                enabled: false
+            },
+            title: {
+                text: 'Rating history'
+            },
+            subtitle: {
+                text: 'Click and drag to zoom'
+            },
+            xAxis: {
+                type: 'datetime',
+                plotLines: [
+                {% for p in patches %}
+                {
+                    value: {{ p.0|milliseconds }},
+                    color: '#cccccc',
+                    width: 2,
+                    label: {
+                        text: '{{ p.1 }}',
+                        verticalAlign: 'bottom',
+                        textAlign: 'right',
+                        y: -2,
+                        style: {
+                            fontSize: '0.8em',
+                        }
+                    }
+                },
+                {% endfor %}]
+            },
+            yAxis: {
+                title: {
+                    text: 'Ranking' 
+                },
+                min: 1000,
+                max: 2100
+            },
+            tooltip: {
+                xDateFormat: '%B %Y',
+                valueDecimals: 1,
+                valueSuffix: '%'
+            },
+            plotOptions: {
+                series: {
+                    marker: {
+                        enabled: true,
+                        symbol: 'circle'
+                    },
+                },
+            },
+             series: [
+            {
+                name: 'toto',
+                color: '#000000',
+                lineWidth: 3,
+                enableMouseTracking: true,
+                data:   [    {x: 1, 2, 3, 4, 
+                          y: 1, 2, 3, 4, }]
+                      
+
+            },
+
+
+
+
+
+
+
+            series: [
+            {% for rat in ratings %}
+            {
+                name: 'toto',
+                color: '#000000',
+                lineWidth: 3,
+                enableMouseTracking: true,
+                data: [{% for r in rat %} {
+                          name: '{{ r.period.end }}: {{r.bf_rating|ratscale }}',
+                          x: {{ r.period.end|milliseconds }},
+                          y: {{ r.bf_rating|ratscale }}
+                      },{% endfor %}]
+
+            },
+            {% endfor %}]
+            {% endcomment %}


### PR DESCRIPTION
Here is my proposed "best players of all time" chart.
Players are sorted by highest ranking achieved

Remaining stuff to do :

1) Fix annoying bug : When clicking on submenu Records / Protoss, Terran, Zerg or All the text of the submenu turn red (correct behavior), but it's not the case for History and Hof.

2) Add a filter for every country. For the moment it's only All | Non-koreans
