### PR TITLE
Added site-wide caching.

### DIFF
--- a/aligulac/aligulac/cache.py
+++ b/aligulac/aligulac/cache.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from aligulac import settings
+from django.views.decorators.cache import cache_page as django_cache_page
+
+def cache_page(f):
+
+    fname = f.__module__ + "." + f.func_name
+    
+    seconds = 60
+    if "CACHE_TIMES" in dir(settings) and fname in settings.CACHE_TIMES:
+        seconds = settings.CACHE_TIMES[fname]
+    
+    if seconds is None:
+        return f
+
+    return django_cache_page(seconds)(f)

--- a/aligulac/aligulac/views.py
+++ b/aligulac/aligulac/views.py
@@ -13,6 +13,8 @@ from django.db.models import Sum, Q
 from django.contrib.auth.models import User
 
 from aligulac.settings import DEBUG, PATH_TO_DIR
+from aligulac.cache import cache_page
+from django.views.decorators.cache import cache_page as django_cache_page
 from ratings.models import Rating, Period, Player, Group, Match, Event, Earnings
 import ratings.tools
 from ratings.templatetags.ratings_extras import urlfilter
@@ -171,6 +173,7 @@ def base_ctx(section=None, subpage=None, request=None, context=None):
 
     return base
 
+@cache_page
 def db(request):
     base = base_ctx('About', 'Database', request)
 
@@ -227,11 +230,13 @@ def db(request):
 
     return render_to_response('db.html', base)
 
+@cache_page
 def staff(request):
     base = base_ctx('About', 'Staff', request)
 
     return render_to_response('staff.html', base)
 
+@cache_page
 def home(request):
     base = base_ctx(request=request)
 
@@ -251,6 +256,7 @@ def home(request):
     
     return render_to_response('index.html', base)
 
+@cache_page
 def search(request, q=''):
     base = base_ctx(request=request)
 

--- a/aligulac/faq/views.py
+++ b/aligulac/faq/views.py
@@ -1,9 +1,12 @@
+from aligulac.cache import cache_page
+
 from django.shortcuts import render_to_response
 from django.http import HttpResponse
 from faq.models import Post
 
 from aligulac.views import base_ctx
 
+@cache_page
 def faq(request):
     posts = Post.objects.order_by('index')
 

--- a/aligulac/ratings/predictviews.py
+++ b/aligulac/ratings/predictviews.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['HOME'] = '/root'
 
+from aligulac.cache import cache_page
 from aligulac.views import base_ctx, Message, NotUniquePlayerMessage
 from ratings.tools import find_player, cdf
 from simul.playerlist import make_player
@@ -14,7 +15,6 @@ from django.db.models import Q, Sum
 from models import Period, Rating, Player, Match
 from django.contrib.auth import authenticate, login
 from django.core.context_processors import csrf
-from django.views.decorators.cache import cache_page
 
 from countries import transformations, data
 
@@ -27,6 +27,7 @@ TL_FOOTER = '[/code][/center][small]Estimated by [url=http://aligulac.com/]Aligu
 REDDIT_HEADER = ''
 REDDIT_FOOTER = '\n\n^Estimated ^by [^Aligulac](http://aligulac.com/)^. [^Modify](%s)^.'
 
+@cache_page
 def predict(request):
     base = base_ctx('Predict', 'Predict', request)
 
@@ -127,7 +128,7 @@ def predict(request):
 
     return render_to_response('predict.html', base)
 
-@cache_page(60)
+@cache_page
 def pred_match(request):
     base = base_ctx('Predict', 'Predict', request=request)
     base['short_url_button'] = True
@@ -261,7 +262,7 @@ def pred_match(request):
                    url='http://aligulac.com/predict/match/?bo=%s&ps=%s' % (base['bo'], base['ps']))
     return render_to_response('pred_match.html', base)
 
-@cache_page(5 * 60)
+@cache_page
 def pred_4pswiss(request):
     base = base_ctx('Predict', 'Predict', request=request)
 
@@ -322,7 +323,7 @@ def pred_4pswiss(request):
                      url='http://aligulac.com/predict/4pswiss/?bo=%s&ps=%s' % (base['bo'], base['ps']))
     return render_to_response('pred_4pswiss.html', base)
 
-@cache_page(10 * 60)
+@cache_page
 def pred_sebracket(request):
     base = base_ctx('Predict', 'Predict', request=request)
 
@@ -398,7 +399,7 @@ def pred_sebracket(request):
                        url='http://aligulac.com/predict/sebracket/?bo=%s&ps=%s' % (base['bo'], base['ps']))
     return render_to_response('pred_sebracket.html', base)
 
-@cache_page(5 * 60)
+@cache_page
 def pred_rrgroup(request):
     base = base_ctx('Predict', 'Predict', request=request)
 
@@ -468,7 +469,7 @@ def pred_rrgroup(request):
                      url='http://aligulac.com/predict/rrgroup/?bo=%s&ps=%s' % (base['bo'], base['ps']))
     return render_to_response('pred_rrgroup.html', base)
 
-@cache_page(5 * 60)
+@cache_page
 def pred_proleague(request):
     base = base_ctx('Predict', 'Predict', request=request)
 

--- a/aligulac/ratings/views.py
+++ b/aligulac/ratings/views.py
@@ -4,6 +4,7 @@ import operator
 import shlex
 from pyparsing import nestedExpr
 
+from aligulac.cache import cache_page
 from aligulac.parameters import RATINGS_INIT_DEV
 from aligulac.views import base_ctx, Message, NotUniquePlayerMessage, generate_messages
 from ratings.tools import find_player, display_matches, cdf, icdf, filter_active_ratings, event_shift,\
@@ -39,6 +40,7 @@ def collect(lst, n=2):
 
     return ret
 
+@cache_page
 def periods(request):
     periods = Period.objects.filter(computed=True).order_by('-start')
 
@@ -47,6 +49,8 @@ def periods(request):
 
     return render_to_response('periods.html', base)
 
+
+@cache_page
 def period(request, period_id, page='1'):
     base = base_ctx('Ranking', 'Current', request)
     psize = 40
@@ -174,6 +178,7 @@ def period(request, period_id, page='1'):
 
     return render_to_response('period.html', base)
 
+@cache_page
 def player(request, player_id):
     player = get_object_or_404(Player, id=player_id)
     base = base_ctx('Ranking', '%s:' % player.tag, request, context=player)
@@ -448,6 +453,7 @@ def player(request, player_id):
                  'teammems': teammems})
     return render_to_response('player.html', base)
 
+@cache_page
 def player_historical(request, player_id):
     player = get_object_or_404(Player, id=player_id)
     base = base_ctx('Ranking', 'Rating history', request, context=player)
@@ -481,6 +487,7 @@ def player_historical(request, player_id):
     base.update({'player': player, 'historical': historical})
     return render_to_response('historical.html', base)
 
+@cache_page
 def results(request):
     base = base_ctx('Results', 'By Date', request)
 
@@ -502,6 +509,7 @@ def results(request):
 
     return render_to_response('results.html', base)
 
+@cache_page
 def results_search(request):
     base = base_ctx('Results', 'Search', request)
     base.update(csrf(request))
@@ -655,6 +663,7 @@ def results_search(request):
 
     return render_to_response('results_search.html', base)
 
+@cache_page
 def events(request, event_id=None):
     # Redirect to proper URL if there's a ?goto=... present
     if 'goto' in request.GET:
@@ -1097,6 +1106,7 @@ def player_results(request, player_id):
     
     return render_to_response('player_results.html', base)
 
+@cache_page
 def player_earnings(request, player_id):
     player = get_object_or_404(Player, id=int(player_id))
 
@@ -1255,6 +1265,7 @@ def earnings(request):
     
     return render_to_response('earnings.html', base)
 
+@cache_page
 def rating_details(request, player_id, period_id):
     period_id = int(period_id)
     player_id = int(player_id)
@@ -1494,6 +1505,7 @@ def records_race(request):
         base.update({'hightot': high, 'highp': highp, 'hight': hight, 'highz': highz, 'dom': dom})
         return render_to_response('records.html', base)
 
+@cache_page
 def balance(request):
     base = base_ctx('Reports', 'Balance', request)
 


### PR DESCRIPTION
The cache function uses the view name and looks up the number of seconds to store the cache in `settings.CACHE_TIMES`. Default is 60 seconds.

Example:

```
_MINUTE = 60
_HOUR = 60 * _MINUTE
_DAY = 24 * _HOUR

CACHE_TIMES = {
    "aligulac.views.home": _HOUR,
    "ratings.predictviews.pred_sebracket": _HOUR,

    "aligulac.views.staff": None
}
```

The above example caches `aligulac.views.home` and `ratings.predictviews.pred_sebracket` for an hour, disables caching for `aligulac.views.staff` and caches all other pages for a minute (default).
