### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,16 @@ pip-log.txt
 # Mac crap
 .DS_Store
 
+#############
+## Emacs
+#############
+
+*~
+
+#############
+## Aligulac
+#############
+
 *.pickle
 *.sql
 aligulac/update


### PR DESCRIPTION
Includes (ignores) emacs backup files.
