### PR TITLE
Expensive event bug.

### DIFF
--- a/aligulac/ratings/results_views.py
+++ b/aligulac/ratings/results_views.py
@@ -474,7 +474,7 @@ class SearchForm(forms.Form):
 
         matches = (
             Match.objects.all().prefetch_related('message_set')
-                .select_related('pla','plb','period')
+                .prefetch_related('pla', 'plb', 'period', 'eventobj')
                 .annotate(Count('eventobj__match'))
         )
 


### PR DESCRIPTION
Fixes a problem where some events caused a very expensive SQL query that can take up to 25 seconds. This uses `prefetch_related` instead of `select_related` which splits the big query with multiple joins into several smaller ones.
