### PR TITLE
Interpolates exchange rates when they are missing on a given day.

### DIFF
--- a/aligulac/currency.py
+++ b/aligulac/currency.py
@@ -1,7 +1,7 @@
-import datetime
 import json
 import urllib
 from aligulac import settings
+from datetime import datetime, timedelta
 from decimal import Decimal
 #Class adapted from https://bitbucket.org/alquimista/currency
 
@@ -41,5 +41,58 @@ class ExchangeRates(object):
         return self._data['rates']
 
     def convert(self, amount, currencyfrom, currencyto='USD'):
+        if currencyfrom not in self.rates:
+            self.interpolate(currencyfrom)
+        if currencyto not in self.rates:
+            self.interpolate(currencyto)
+
         usd = self._tobase(amount, currencyto.upper())
         return usd / Decimal(self.rates[currencyfrom.upper()])
+
+    def interpolate(self, currency):
+        """
+        Linearly interpolates the rate for `currency`
+        by using the rates closest before and after the
+        current date.
+        """
+        one_day = timedelta(days=1)
+
+        after = self._date + one_day
+        nafter = 1
+        before = self._date - one_day
+        nbefore = 1
+
+        rate_after = None
+        rate_before = None
+
+        tries = 0
+        while rate_after is None and tries < 20:
+            e = ExchangeRates(after)
+            if currency in e.rates:
+                rate_after = e.rates[currency]
+                break
+            after += one_day
+            nafter += 1
+            tries += 1
+
+        tries = 0
+        while rate_before is None and tries < 20 and rate_after is not None:
+            e = ExchangeRates(before)
+            if currency in e.rates:
+                rate_before = e.rates[currency]
+                break
+            before -= one_day
+            nbefore += 1
+            tries += 1
+
+        if rate_after is None or rate_after is None:
+            raise RateNotFoundError(currency, self._date)
+
+        coeff = (rate_after - rate_before) / (nafter + nbefore)
+        self.rates[currency] =  rate_before + coeff * nbefore
+
+
+class RateNotFoundError(Exception):
+    def __init__(self, currency, date, *args, **kwargs):
+        super().__init__("Exchange rate not found for currency"\
+                            " {} on {}".format(currency, date), *args, **kwargs)

--- a/aligulac/ratings/ranking_views.py
+++ b/aligulac/ratings/ranking_views.py
@@ -197,7 +197,7 @@ def earnings(request):
     # }}}
 
     # {{{ Initial filtering of earnings
-    preranking = Earnings.objects
+    preranking = Earnings.objects.filter(earnings__isnull=False)
 
     # Filtering by year
     year = get_param(request, 'year', 'all')

--- a/aligulac/ratings/results_views.py
+++ b/aligulac/ratings/results_views.py
@@ -42,6 +42,8 @@ from aligulac.tools import (
     StrippedCharField,
 )
 
+from currency import RateNotFoundError
+
 from ratings.models import (
     CAT_FREQUENT,
     CAT_INDIVIDUAL,
@@ -269,8 +271,14 @@ class PrizepoolModForm(forms.Form):
         # }}}
 
         # {{{ Commit
-        Earnings.set_earnings(event, ranked,   self.cleaned_data['currency'], True)
-        Earnings.set_earnings(event, unranked, self.cleaned_data['currency'], False)
+        try:
+            Earnings.set_earnings(event, ranked,
+                                  self.cleaned_data['currency'], True)
+            Earnings.set_earnings(event, unranked,
+                                  self.cleaned_data['currency'], False)
+        except RateNotFoundError as e:
+            ret.append(Message(str(e), type=Message.ERROR))
+            return ret
         # }}}
 
         ret.append(Message('New prizes committed.', type=Message.SUCCESS))


### PR DESCRIPTION
In the case that some still get through, don't show them on the leaderboard.

This also shows an error message if the exchange rate isn't found when submitting
the prize pool for an event.

Fixes #127
