### PR TITLE
added field "Algulac ID" to right hand side table of the player page

### DIFF
--- a/templates/player.djhtml
+++ b/templates/player.djhtml
@@ -694,6 +694,10 @@ This is the template for the main player page, called from ratings.views.player.
               <td>{{player.mcnum}}</td>
             </tr>
           {% endif %}
+            <tr class="small">
+              <td class="text-right ibox-left">{% trans "Aligulac ID" %}</td>
+              <td>{{player.id}}</td>
+            </tr>
           {% if player.tlpd_id or player.lp_name or player.sc2e_id %}
             <tr class="small">
               <td class="text-right ibox-left">{% trans "External" %}</td>


### PR DESCRIPTION
Felt like this was a good addition.

The guide for how to used the search function includes:
- A player ID number, which you can get from the URL of the player page, e.g. "4" 

This is obviously not very clean or well designed, and a lot of browsers (mostly mobile ones) hide the full URL while you browse.
